### PR TITLE
Remove any documentations about lower level API from the docs for now

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,8 @@
 # API
 
+<!-- ## Client
 ::: src.cpln.api.client.APIClient
-	options:
-		show_root_heading: true
+
+## Workloads
+::: src.cpln.api.workload.WorkloadApiMixin
+::: src.cpln.api.workload.WorkloadDeploymentMixin -->

--- a/docs/gvcs.md
+++ b/docs/gvcs.md
@@ -3,9 +3,4 @@
 See [this documentation](https://docs.controlplane.com/concepts/gvc) to learn more about GVC (Global Virtual Cloud).
 
 ::: src.cpln.models.gvcs.GVC
-	options:
-		show_root_heading: true
-
 ::: src.cpln.models.gvcs.GVCCollection
-	options:
-		show_root_heading: true

--- a/docs/images.md
+++ b/docs/images.md
@@ -1,9 +1,4 @@
 # Images
 
 ::: src.cpln.models.images.Image
-	options:
-		show_root_heading: true
-
 ::: src.cpln.models.images.ImageCollection
-	options:
-		show_root_heading: true

--- a/docs/workloads.md
+++ b/docs/workloads.md
@@ -1,9 +1,4 @@
 # Workloads
 
 ::: src.cpln.models.workloads.Workload
-	options:
-		show_root_heading: true
-
 ::: src.cpln.models.workloads.WorkloadCollection
-	options:
-		show_root_heading: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ plugins:
       handlers:
         python:
           options:
-            docstring_section_style: list
+            # docstring_section_style: list
             members_order: source
             show_root_heading: true
             show_source: false

--- a/src/cpln/api/client.py
+++ b/src/cpln/api/client.py
@@ -13,7 +13,7 @@ class APIClient(
     GVCApiMixin,
     ImageApiMixin,
     WorkloadApiMixin,
-    WorkloadDeploymentMixin,
+    WorkloadDeploymentMixin, #TODO: Test if I can remove this
 ):
     """
     A low-level client for the Control Plane API.
@@ -45,6 +45,15 @@ class APIClient(
     def _get(self,
         endpoint: str
     ):
+        """
+        Makes a GET request to the specified API endpoint.
+
+        Args:
+            endpoint (str): The API endpoint to request
+
+        Returns:
+            dict: The JSON response from the API
+        """
         resp = self.get(
             f"{self.config.org_url}/{endpoint}",
             headers = self._headers
@@ -54,6 +63,15 @@ class APIClient(
     def _delete(self,
         endpoint: str
     ):
+        """
+        Makes a DELETE request to the specified API endpoint.
+
+        Args:
+            endpoint (str): The API endpoint to delete
+
+        Returns:
+            requests.Response: The response object from the API
+        """
         return self.delete(
             f"{self.config.org_url}/{endpoint}",
             headers = self._headers
@@ -63,6 +81,16 @@ class APIClient(
         endpoint: str,
         data: dict[str, any] | None = None
     ):
+        """
+        Makes a PATCH request to the specified API endpoint.
+
+        Args:
+            endpoint (str): The API endpoint to update
+            data (dict, optional): The data to send in the request body
+
+        Returns:
+            requests.Response: The response object from the API
+        """
         return self.patch(
             f"{self.config.org_url}/{endpoint}",
             json = data,

--- a/src/cpln/api/config.py
+++ b/src/cpln/api/config.py
@@ -10,6 +10,20 @@ from ..constants import (
 
 @dataclass
 class APIConfig:
+    """
+    Configuration class for the Control Plane API client.
+
+    This class holds the configuration parameters needed to interact with the Control Plane API,
+    including authentication details, organization information, and API settings.
+
+    Args:
+        token (str): Authorization token for accessing the API
+        org (str): Organization name in Control Plane
+        base_url (str, optional): Base URL for the Control Plane API. Defaults to DEFAULT_CPLN_API_URL
+        version (str, optional): API version to use. Defaults to DEFAULT_CPLN_API_VERSION
+        timeout (int, optional): Request timeout in seconds. Defaults to DEFAULT_TIMEOUT_SECONDS
+        org_url (str, optional): Organization-specific API URL. Will be automatically set based on base_url and org
+    """
     token: str
     org: str
     base_url: str = DEFAULT_CPLN_API_URL
@@ -18,10 +32,25 @@ class APIConfig:
     org_url: str = None
 
     def __post_init__(self):
+        """
+        Post-initialization hook that sets the organization URL.
+        """
         self.org_url = self.get_org_url()
 
     def get_org_url(self) -> str:
+        """
+        Constructs and returns the organization-specific API URL.
+
+        Returns:
+            str: The complete URL for the organization's API endpoint
+        """
         return f"{self.base_url}/org/{self.org}"
 
     def asdict(self):
+        """
+        Converts the configuration object to a dictionary.
+
+        Returns:
+            dict: A dictionary containing all configuration parameters
+        """
         return asdict(self)

--- a/src/cpln/api/gvc.py
+++ b/src/cpln/api/gvc.py
@@ -1,7 +1,23 @@
 class GVCApiMixin:
+    """
+    A mixin class that provides GVC (Global Virtual Cluster) related API methods.
+    """
     def get_gvc(self,
         name: str = None
     ):
+        """
+        Retrieves GVC information from the Control Plane API.
+
+        Args:
+            name (str, optional): The name of the specific GVC to retrieve.
+                If not provided, returns a list of all GVCs.
+
+        Returns:
+            dict: The GVC information or list of GVCs
+
+        Raises:
+            APIError: If the request fails
+        """
         endpoint = 'gvc'
         if name:
             endpoint += f'/{name}'
@@ -11,9 +27,31 @@ class GVCApiMixin:
         name: str,
         description: str = None
     ):
+        """
+        Creates a new GVC in the Control Plane.
+
+        Args:
+            name (str): The name of the GVC to create
+            description (str, optional): A description of the GVC
+
+        Raises:
+            ValueError: Currently not implemented
+        """
         raise ValueError('Not implemented! The payload to do this is annoyingly long, so somebody else do it.')
 
     def delete_gvc(self,
         name: str
     ):
+        """
+        Deletes a GVC from the Control Plane.
+
+        Args:
+            name (str): The name of the GVC to delete
+
+        Returns:
+            requests.Response: The response from the API
+
+        Raises:
+            APIError: If the request fails
+        """
         return self._delete(f'gvc/{name}')

--- a/src/cpln/api/image.py
+++ b/src/cpln/api/image.py
@@ -1,12 +1,39 @@
 class ImageApiMixin:
-
+    """
+    A mixin class that provides image-related API methods.
+    """
     def get_image(self,
         image_id: str = None
     ):
+        """
+        Retrieves image information from the Control Plane API.
+
+        Args:
+            image_id (str, optional): The ID of the specific image to retrieve.
+                If not provided, returns a list of all images.
+
+        Returns:
+            dict: The image information or list of images
+
+        Raises:
+            APIError: If the request fails
+        """
         endpoint = 'image'
         if image_id:
             endpoint += f'/{image_id}'
         return self._get(endpoint)
 
     def delete_image(self, image_id):
+        """
+        Deletes an image from the Control Plane.
+
+        Args:
+            image_id (str): The ID of the image to delete
+
+        Returns:
+            requests.Response: The response from the API
+
+        Raises:
+            APIError: If the request fails
+        """
         return self._delete(f'image/{image_id}')

--- a/src/cpln/api/workload.py
+++ b/src/cpln/api/workload.py
@@ -11,10 +11,25 @@ IGNORED_CONTAINERS = ["cpln-mounter"]
 
 
 class WorkloadDeploymentMixin:
-
+    """
+    A mixin class that provides workload deployment-related API methods.
+    """
     def get_workload_deployment(self,
         config: WorkloadConfig
     ) -> dict[str, Any]:
+        """
+        Retrieves deployment information for a specific workload.
+
+        Args:
+            config (WorkloadConfig): Configuration object containing workload details
+
+        Returns:
+            dict: Deployment information for the workload
+
+        Raises:
+            ValueError: If the config is not properly set
+            APIError: If the request fails
+        """
         if config.workload_id is None or config.location is None:
             raise ValueError("Config not set properly")
 
@@ -26,6 +41,16 @@ class WorkloadDeploymentMixin:
         api_config: APIConfig,
         config: WorkloadConfig
     ):
+        """
+        Creates a new API client instance for remote operations.
+
+        Args:
+            api_config (APIConfig): API configuration
+            config (WorkloadConfig): Workload configuration
+
+        Returns:
+            WorkloadDeploymentMixin: A new instance configured for remote operations
+        """
         env = api_config.asdict()
         env["base_url"] = cls(**env).get_remote(config) + "/replicas"
         return cls(**env)
@@ -33,16 +58,43 @@ class WorkloadDeploymentMixin:
     def get_remote(self,
         config: WorkloadConfig
     ) -> str:
+        """
+        Gets the remote URL for a workload deployment.
+
+        Args:
+            config (WorkloadConfig): Configuration object containing workload details
+
+        Returns:
+            str: The remote URL for the workload deployment
+        """
         return self.get_workload_deployment(config)["status"]["remote"]
 
     def get_remote_wss(self,
         config: WorkloadConfig
     ) -> str:
+        """
+        Gets the WebSocket URL for a workload deployment.
+
+        Args:
+            config (WorkloadConfig): Configuration object containing workload details
+
+        Returns:
+            str: The WebSocket URL for the workload deployment
+        """
         return self.get_remote(config).replace("https:", "wss:") + "/remote"
 
     def get_replicas(self,
         config: WorkloadConfig
     ) -> list[str]:
+        """
+        Gets the list of replicas for a workload.
+
+        Args:
+            config (WorkloadConfig): Configuration object containing workload details
+
+        Returns:
+            list[str]: List of replica names
+        """
         remote_api_client = self.get_remote_api(self.config, config)
         replicas = remote_api_client._get(f"/gvc/{config.gvc}/workload/{config.workload_id}")["items"]
         return replicas
@@ -51,6 +103,16 @@ class WorkloadDeploymentMixin:
         config: WorkloadConfig,
         ignored_containers: list[str] = IGNORED_CONTAINERS
     ) -> list[str]:
+        """
+        Gets the list of containers for a workload, excluding ignored containers.
+
+        Args:
+            config (WorkloadConfig): Configuration object containing workload details
+            ignored_containers (list[str], optional): List of container names to ignore
+
+        Returns:
+            list[str]: List of container names
+        """
         item = self.get_workload_deployment(config)
         workload_versions = item["status"]["versions"]
         containers = [
@@ -62,11 +124,24 @@ class WorkloadDeploymentMixin:
 
 
 class WorkloadApiMixin(WorkloadDeploymentMixin):
-
+    """
+    A mixin class that provides workload-related API methods.
+    """
     def get_workload(self,
         config: WorkloadConfig
     ):
-        """Get a workload by its ID."""
+        """
+        Retrieves information about a workload.
+
+        Args:
+            config (WorkloadConfig): Configuration object containing workload details
+
+        Returns:
+            dict: Workload information
+
+        Raises:
+            APIError: If the request fails
+        """
         endpoint = f'gvc/{config.gvc}/workload'
         if config.workload_id:
             endpoint += f'/{config.workload_id}'
@@ -75,7 +150,18 @@ class WorkloadApiMixin(WorkloadDeploymentMixin):
     def delete_workload(self,
         config: WorkloadConfig
     ):
-        """Delete a workload by its ID."""
+        """
+        Deletes a workload.
+
+        Args:
+            config (WorkloadConfig): Configuration object containing workload details
+
+        Returns:
+            requests.Response: The response from the API
+
+        Raises:
+            APIError: If the request fails
+        """
         endpoint = f'gvc/{config.gvc}/workload/{config.workload_id}'
         return self._delete(endpoint)
 
@@ -83,7 +169,19 @@ class WorkloadApiMixin(WorkloadDeploymentMixin):
         config: WorkloadConfig,
         data: dict[str, Any]
     ):
-        """Patch a workload by its ID."""
+        """
+        Updates a workload with the provided data.
+
+        Args:
+            config (WorkloadConfig): Configuration object containing workload details
+            data (dict): The data to update the workload with
+
+        Returns:
+            requests.Response: The response from the API
+
+        Raises:
+            APIError: If the request fails
+        """
         endpoint = f'gvc/{config.gvc}/workload/{config.workload_id}'
         return self._patch(endpoint, data=data)
 
@@ -91,6 +189,19 @@ class WorkloadApiMixin(WorkloadDeploymentMixin):
         config: WorkloadConfig,
         command: str
     ):
+        """
+        Executes a command in a workload container.
+
+        Args:
+            config (WorkloadConfig): Configuration object containing workload details
+            command (str): The command to execute
+
+        Returns:
+            Any: The result of the command execution
+
+        Raises:
+            APIError: If the request fails
+        """
         containers = self.get_containers(config)
         replicas = self.get_replicas(config)
         remote_wss = self.get_remote_wss(config)


### PR DESCRIPTION
I don't like the current formatting of things. So I will make all the other documentations first, then figure out how to implement these.