### PR TITLE
docs: update README with correct example commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,11 @@ clean:
 	find . -name ".mypy_cache" -type d -prune -exec rm -rf {} +
 
 lint:
-	ruff check .
-	mypy src/cpln
+	pdm run ruff check .
+	pdm run mypy src/cpln
 
 format:
-	ruff format .
+	pdm run ruff format .
 
 test:
 	pdm run pytest

--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ git clone https://github.com/dave6892/cpln-py.git
 cd cpln-py
 
 # Install dependencies
-pdm install
+make install
 
-# Run example to verify installation
-pdm run main.py
+# Run examples to verify installation
+pdm run python examples/example_cpln_gvc.py
+pdm run python examples/example_cpln_images.py
+pdm run python examples/example_cpln_workload.py
 ```
 
 ## Requirements
@@ -258,7 +260,7 @@ client = cpln.CPLNClient(
 
 ```bash
 # Run all tests
-pdm run pytest
+make test
 
 # Run with coverage
 pdm run pytest --cov=src/cpln
@@ -284,8 +286,8 @@ pdm run mypy src/
 ### Documentation
 
 ```bash
-# Build documentation
-pdm run mkdocs serve
+# Build and serve documentation
+make docs
 ```
 
 ## API Reference
@@ -311,8 +313,8 @@ The SDK is organized into several key components:
 2. Create a feature branch (`git checkout -b feature/amazing-feature`)
 3. Make your changes
 4. Add tests for your changes
-5. Ensure all tests pass (`pdm run pytest`)
-6. Run code quality checks (`pdm run ruff check .` and `pdm run ruff format .`)
+5. Ensure all tests pass (`make test`)
+6. Run code quality checks (`make lint` and `make format`)
 7. Commit your changes (`git commit -m 'Add amazing feature'`)
 8. Push to the branch (`git push origin feature/amazing-feature`)
 9. Open a Pull Request


### PR DESCRIPTION
## Changes Made
- Updated the development installation section to use the correct `make install` command
- Added commands to run all three example files:
  - `example_cpln_gvc.py` for getting GVC
  - `example_cpln_images.py` for getting image
  - `example_cpln_workload.py` for workload operations

## Objective
The README contained outdated and incorrect information about running examples. These changes ensure users can properly verify their installation and see `cpln-py` in action through the provided examples.

## Testing
- Verified all example files exist in the `examples/` directory
- Confirmed example commands work with PDM